### PR TITLE
feat: add docker-entrypoint to automate migrations during container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,11 @@ RUN chown -R \
     3000:3000 \
     /app
 
+RUN chmod +x \
+    /app/docker-entrypoint.sh
+
 USER 3000
 RUN bun install
 
 EXPOSE 3000
-CMD ["bun", "start"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Entrypoint script for Dunya
+# SPDX-License-Identifier: BSD-3-Clause (https://ncurl.xyz/s/mI23sevHR)
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Run database migrations
+bun run db:migrate
+
+# Start the application
+exec bun run start


### PR DESCRIPTION
Automate database migrations during the Docker container startup phase by using a `docker-entrypoint.sh` script.

Key changes:
- Created `docker-entrypoint.sh` with `set -e`, `bun run db:migrate`, and `exec bun run start`.
- Updated `Dockerfile` to set `/app/docker-entrypoint.sh` as the `ENTRYPOINT`.
- Ensured the entrypoint is executable within the container.